### PR TITLE
Поддержка php 5.6

### DIFF
--- a/src/Translit.php
+++ b/src/Translit.php
@@ -13,7 +13,7 @@ class Translit
     protected $maxLength;
 
 
-    public function __construct(String $text = '', $maxLength = 255)
+    public function __construct($text = '', $maxLength = 255)
     {
         $this->text = trim($text);
 


### PR DESCRIPTION
Заявлен 5.6, но на нём падает с ошибкой
> Fatal error: Default value for parameters with a class type hint can only be NULL in vendor/denismitr/translit/src/Translit.php on line 16")

Убрал указание типа. Как вариант вернуть его, но поставить php7+